### PR TITLE
#163480459 implement email notification and forget password endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,6 +127,68 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@sendgrid/client": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-6.3.0.tgz",
+      "integrity": "sha512-fTy8vRpA9Whtf8ULQr/0vkSZaQvGQ97rY5N5PrevKRtugJMsJqFMKO0pwzEWeqITSg71aMMTj57QTgw3SjZvnQ==",
+      "requires": {
+        "@sendgrid/helpers": "^6.3.0",
+        "@types/request": "^2.0.3",
+        "request": "^2.81.0"
+      }
+    },
+    "@sendgrid/helpers": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-6.3.0.tgz",
+      "integrity": "sha512-uTFcmhCDFg/2Uhz+z/cLwyLHH0UsblG49hKwdR7nKbWsGKWv4js7W32FlPdXqy2C/plTJ20vcPLgKM1m3F/MjQ==",
+      "requires": {
+        "chalk": "^2.0.1",
+        "deepmerge": "^2.1.1"
+      }
+    },
+    "@sendgrid/mail": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-6.3.1.tgz",
+      "integrity": "sha512-5zIeAV9iU+0hQkrOQ/D4RB2MfpK+lNbOortIfQdCh95aMDF/TRc9WB8FGNhmQrx9YMuJTms5eiBklF0Fi/dbVg==",
+      "requires": {
+        "@sendgrid/client": "^6.3.0",
+        "@sendgrid/helpers": "^6.3.0"
+      }
+    },
+    "@types/caseless": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
+    },
+    "@types/form-data": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "10.12.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+    },
+    "@types/request": {
+      "version": "2.48.1",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
+      "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
+      "requires": {
+        "@types/caseless": "*",
+        "@types/form-data": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*"
+      }
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1719,6 +1781,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
     },
     "define-properties": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/Akinmyde/Questioner#readme",
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
+    "@sendgrid/mail": "^6.3.1",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "body-parser": "^1.18.3",

--- a/server/app.js
+++ b/server/app.js
@@ -11,7 +11,9 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 
 app.use('/api/v1', router);
-
+app.all('*', (req, res) => {
+  res.status(404).send({ status: 404, error: 'Sorry, the page you tried cannot be found' });
+});
 app.listen(port, () => {
   console.log(`listening on port ${chalk.blue(port)}`);
 });

--- a/server/config/connection.js
+++ b/server/config/connection.js
@@ -15,7 +15,7 @@ const connectionString = config[env];
 
 const pool = new Pool({
   connectionString,
-  connectionTimeoutMillis: 3000,
+  connectionTimeoutMillis: 10000,
   idleTimeoutMillis: 2000,
   max: 5,
   min: 4,

--- a/server/config/email.js
+++ b/server/config/email.js
@@ -1,0 +1,19 @@
+
+import sgMail from '@sendgrid/mail';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+
+const sendEmail = (to, subject, message) => {
+  const msg = {
+    to,
+    from: 'no-reply@questioner.com',
+    subject,
+    html: message,
+  };
+  sgMail.send(msg);
+};
+
+export default sendEmail;

--- a/server/helpers/notification.js
+++ b/server/helpers/notification.js
@@ -1,0 +1,30 @@
+import jwt from 'jsonwebtoken';
+import sendEmail from '../config/email';
+import template from './template';
+
+class Notification {
+  static signUp(email) {
+    const subject = 'Welcome to Questioner!!!';
+    const message = template('<p>We are trilled to have you...</p> <p>At Questioner, we know the importance of Meetups and Questions. That\'s is why we are here to help you prioritize questions for your meetup. With Questioner, you don\'t need to worry about the trending question/questions for your meetup we already got that covered for you</p>');
+
+    sendEmail(email, subject, message);
+  }
+
+  static forgetPassword(email, url) {
+    const token = jwt.sign({ email }, process.env.SECRET, { expiresIn: '12h' });
+    const link = url + token;
+    const subject = 'Password Reset';
+    const message = template(`<p>Someone, probably you requested for a password reset</p> <p>follow this link to reset your password <a href=${link}>Reset my password</a></p><br><b>Please note that this link expires in 12hours and you can only use it once</b><p>If you didn't request for a password reset, ignore this email and nothing will happen</p>`);
+
+    sendEmail(email, subject, message);
+  }
+
+  static passwordReset(email) {
+    const subject = 'Password was changed';
+    const message = template('<p>Your password was changed successfuly</p>');
+
+    sendEmail(email, subject, message);
+  }
+}
+
+export default Notification;

--- a/server/helpers/template.js
+++ b/server/helpers/template.js
@@ -1,0 +1,40 @@
+const template = message => `<div style="font-family:-apple-system, '.SFNSText-Regular', 'Helvetica Neue', Roboto, 'Segoe UI', sans-serif; color: #666666; background:white; text-decoration: none;  margin-bottom: 50px">
+    <table width="100%" cellpadding="0" cellspacing="0" border="0" summary="">
+      <tr align="center">
+        <td valign="top" style="width: 100%;">
+          <table cellspacing="0" cellpadding="0" border="0" summary="">
+            <tr align="center">
+              <td valign="middle" style="width: 100%;">
+                <a href="https://akinmyde.github.io/Questioner/UI">
+                  <img style="width: 125px; cursor: pointer" src="https://res.cloudinary.com/codeace/image/upload/v1548425091/Questioner/new_logo.png" alt="Questioner">
+                </a>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+      <tr align="center">
+        <td valign="top" style="width: 100%;">
+          <table style="padding: 0px; border: 0; max-width: 520px; text-align: center;" width="100%" cellpadding="0" cellspacing="0" border="0" summary="">
+            <tr align="center" style="margin: 0px 10px;">
+              <td style="width: 100%; line-height: 24px; font-size: 11pt;">
+                <p>Howdy,</p>
+                <p>${message}</p>
+              </td>
+            </tr>
+          </table>
+          <table style="border-collapse:collapse; max-width: 520px; text-align: center; margin-top: 30px" cellpadding="0" cellspacing="0" border="0" summary="">
+            <tr align="center">
+              <td style="width: 100%;">
+                <p style="line-height: 20px; font-size: 0.75rem; color: #b3b3b3;">Sent by
+                  <a href="https://akinmyde.github.io/Questioner/UI" style="color: #4a08ef;text-decoration: none;">Questioner</a>
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </div>`;
+
+export default template;

--- a/server/middlewares/index.js
+++ b/server/middlewares/index.js
@@ -125,6 +125,25 @@ export default class Middleware {
     });
   }
 
+  static validateForgetPassword(req, res, next) {
+    const { email } = req.body;
+    if (!email || validate({ from: email }, constraints)) {
+      return res.status(400).send({ status: 400, error: 'email is required and must be valid' });
+    }
+    return next();
+  }
+
+  static validateResetPassword(req, res, next) {
+    const { password } = req.body;
+    if (!validate.isString(password) || validate.isEmpty(password)) {
+      return res.status(400).send({ status: 400, error: 'password is required and must be a string' });
+    }
+    if (password.length < 8) {
+      return res.status(400).send({ status: 400, error: 'Password lenght is too short, it should be at least 8 character long' });
+    }
+    return next();
+  }
+
   static validateUserSignup(req, res, next) {
     const { email, username, password } = req.body;
     const error = {};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,7 +1,7 @@
 import express from 'express';
-import meetupRouter from './meetupRoute';
-import questionRouter from './questionRoute';
-import userRoute from './userRouter';
+import meetupRoute from './meetupRoute';
+import questionRoute from './questionRoute';
+import userRoute from './userRoute';
 import commentRoute from './commentRoute';
 
 const router = express.Router();
@@ -10,16 +10,12 @@ router.get('/', (req, res) => {
   res.status(200).send('Welcome to my questioner app endpoint');
 });
 
-router.use('/meetups', meetupRouter);
+router.use('/meetups', meetupRoute);
 
-router.use('/questions', questionRouter);
+router.use('/questions', questionRoute);
 
 router.use('/auth', userRoute);
 
 router.use('/questions', commentRoute);
-
-router.all('*', (req, res) => {
-  res.status(404).send({ status: 404, error: 'Sorry, the page you tried cannot be found' });
-});
 
 export default router;

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -11,5 +11,9 @@ userRoute.post('/login', Middleware.validateUserSignin, userController.signIn);
 
 userRoute.put('/profile', Middleware.isLogin, Middleware.validateUserProfile, userController.profile);
 
+userRoute.post('/forget', Middleware.validateForgetPassword, userController.forgetPassword);
+
+userRoute.patch('/reset/:token', Middleware.validateResetPassword, userController.resetPassword);
+
 
 export default userRoute;

--- a/server/test/index.test.js
+++ b/server/test/index.test.js
@@ -44,6 +44,34 @@ describe('Meetup Test', () => {
       }
     });
   });
+  describe('Forget Password', () => {
+    it('should response with status code 200 if email is valid', async () => {
+      try {
+        const res = await request(app)
+          .post('/api/v1/auth/forget')
+          .set('Accept', 'application/json')
+          .send({ email: 'superuser@yahoo.com' });
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.status).toEqual(200);
+        expect(res.body.message).toEqual('Check you email for the next step');
+      } catch (error) {
+        console.log(error);
+      }
+    });
+    it('should response with status code 404 if email is not valid', async () => {
+      try {
+        const res = await request(app)
+          .post('/api/v1/auth/forget')
+          .set('Accept', 'application/json')
+          .send({ email: 'unknownemail@yahoo.com' });
+        expect(res.statusCode).toEqual(404);
+        expect(res.body.status).toEqual(404);
+        expect(res.body.error).toEqual('User not found');
+      } catch (error) {
+        console.log(error);
+      }
+    });
+  });
   describe('Update Profile', () => {
     it('should response with status code 200 and user profile was updated', async () => {
       try {
@@ -176,6 +204,104 @@ describe('Meetup Test', () => {
     });
   });
   describe('Middleware test', () => {
+    describe('Validate forget password', () => {
+      it('should return status code 400 and message email is required and must be valid', (done) => {
+        request(app)
+          .post('/api/v1/auth/forget')
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(400)
+          .expect((res) => {
+            expect(res.body.status).toEqual(400);
+            expect(res.body.error).toEqual('email is required and must be valid');
+          })
+          .end((err) => {
+            if (err) return done(err);
+            return done();
+          });
+      });
+      it('should return status code 400 and message email is required and must be valid', (done) => {
+        request(app)
+          .post('/api/v1/auth/forget')
+          .send({ email: '' })
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(400)
+          .expect((res) => {
+            expect(res.body.status).toEqual(400);
+            expect(res.body.error).toEqual('email is required and must be valid');
+          })
+          .end((err) => {
+            if (err) return done(err);
+            return done();
+          });
+      });
+      it('should return status code 400 if email is not valid', (done) => {
+        request(app)
+          .post('/api/v1/auth/forget')
+          .send({ email: 'j@j' })
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(400)
+          .expect((res) => {
+            expect(res.body.status).toEqual(400);
+            expect(res.body.error).toEqual('email is required and must be valid');
+          })
+          .end((err) => {
+            if (err) return done(err);
+            return done();
+          });
+      });
+    });
+    describe('Password Reset', () => {
+      it('should return status code 400 if password not provided', (done) => {
+        request(app)
+          .patch('/api/v1/auth/reset/bjkdbfjkbkj')
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(400)
+          .expect((res) => {
+            expect(res.body.status).toEqual(400);
+            expect(res.body.error).toEqual('password is required and must be a string');
+          })
+          .end((err) => {
+            if (err) return done(err);
+            return done();
+          });
+      });
+      it('should return status code 400 if password is empty', (done) => {
+        request(app)
+          .patch('/api/v1/auth/reset/bjkdbfjkbkj')
+          .send({ password: '' })
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(400)
+          .expect((res) => {
+            expect(res.body.status).toEqual(400);
+            expect(res.body.error).toEqual('password is required and must be a string');
+          })
+          .end((err) => {
+            if (err) return done(err);
+            return done();
+          });
+      });
+      it('should return status code 400 if password is less than 8 char', (done) => {
+        request(app)
+          .patch('/api/v1/auth/reset/bjkdbfjkbkj')
+          .send({ password: 'test' })
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(400)
+          .expect((res) => {
+            expect(res.body.status).toEqual(400);
+            expect(res.body.error).toEqual('Password lenght is too short, it should be at least 8 character long');
+          })
+          .end((err) => {
+            if (err) return done(err);
+            return done();
+          });
+      });
+    });
     describe('Validate Profile', () => {
       it('should return status code 400', (done) => {
         request(app)


### PR DESCRIPTION
__What does this PR do?__
implement email notification and forget password endpoint

__Description of Task to be completed?__
* `design an email template`
* `configure SendGrid for sending emails`
* `add route for password reset and forget password (/auth/reset and /auth/forget)`
* `write tests for user forget password and reset endpoint`
* `write logic for sending emails`

__How should this be manually tested?__
`Clone the repo`
`Checkout to branch<ft-email-163480459>`
`Using Postman test all endpoints`

__What are the relevant pivotal tracker stories?__
#163480459

__Screenshots__
![forget password](https://user-images.githubusercontent.com/26759774/51803542-a3abfc00-2256-11e9-87b8-0ed0726e2738.PNG)

![password changed](https://user-images.githubusercontent.com/26759774/51803548-b9212600-2256-11e9-8a18-dc8791060aec.PNG)

